### PR TITLE
Add Maybe optional to make it easier to handle None

### DIFF
--- a/basilisp/lang/runtime.py
+++ b/basilisp/lang/runtime.py
@@ -1,7 +1,9 @@
 import pkg_resources
+
 import basilisp.lang.namespace as namespace
 import basilisp.lang.symbol as sym
 import basilisp.lang.var as var
+from basilisp.util import Maybe
 
 _CORE_NS = namespace._CORE_NS
 _CORE_NS_FILE = 'core.lpy'
@@ -55,9 +57,8 @@ def bootstrap(ns_var_name=_NS_VAR_NAME, core_ns_name=_CORE_NS) -> None:
     __NS = var.find(ns_var_sym)
 
     def set_BANG_(var_sym: sym.Symbol, expr):
-        ns, name = None, var_sym.name
-        if var_sym.ns is None:
-            ns = __NS.value.name
+        ns = Maybe(var_sym.ns).or_else(lambda: __NS.value.name)
+        name = var_sym.name
 
         v = var.find(sym.symbol(name, ns=ns))
         v.value = expr

--- a/basilisp/util.py
+++ b/basilisp/util.py
@@ -1,8 +1,10 @@
 import functools
 import inspect
 import os.path
+from typing import TypeVar, Generic, Optional, Callable
 
 from functional import seq
+from functional.pipeline import Sequence
 
 from basilisp.lang.util import lrepr
 
@@ -35,3 +37,58 @@ def trace(f):
             raise e
 
     return wrapper
+
+
+T = TypeVar('T')
+U = TypeVar('U')
+
+
+class Maybe(Generic[T]):
+    __slots__ = ('_inner', )
+
+    def __init__(self, inner: Optional[T]) -> None:
+        self._inner = inner
+
+    def __eq__(self, other):
+        if isinstance(other, Maybe):
+            return self._inner == other.value
+        return self._inner == other
+
+    def __repr__(self):
+        return repr(self._inner)
+
+    def __str__(self):
+        return str(self._inner)
+
+    def or_else(self, else_fn: Callable[[], T]) -> T:
+        if self._inner is None:
+            return else_fn()
+        return self._inner
+
+    def or_else_get(self, else_v: T) -> T:
+        if self._inner is None:
+            return else_v
+        return self._inner
+
+    def or_else_raise(self, raise_fn: Callable[[], Exception]) -> T:
+        if self._inner is None:
+            raise raise_fn()
+        return self._inner
+
+    def map(self, f: Callable[[T], U]) -> "Maybe[U]":
+        if self._inner is None:
+            return Maybe(None)
+        return Maybe(f(self._inner))
+
+    @property
+    def value(self) -> Optional[T]:
+        return self._inner
+
+    def stream(self) -> Sequence:
+        if self._inner is None:
+            return seq([])
+        return seq([self._inner])
+
+    @property
+    def is_present(self) -> bool:
+        return self._inner is not None

--- a/tests/maybe_test.py
+++ b/tests/maybe_test.py
@@ -1,0 +1,54 @@
+import pytest
+
+from basilisp.util import Maybe
+
+
+def test_maybe_is_present():
+    assert Maybe(None).is_present is False
+    assert Maybe("Something").is_present
+
+
+def test_maybe_value():
+    assert Maybe(None).value is None
+    assert Maybe("Something").value == "Something"
+
+
+def test_maybe_equals():
+    assert Maybe("Something") == "Something"
+    assert Maybe("Something") == Maybe("Something")
+    assert Maybe(None) == Maybe(None)
+    assert Maybe(None) != Maybe("Something")
+
+
+def test_maybe_or_else():
+    assert Maybe(None).or_else(lambda: "Not None") == "Not None"
+    assert Maybe("Something").or_else(lambda: "Nothing") == "Something"
+
+
+def test_maybe_or_else_get():
+    assert Maybe(None).or_else_get("Not None") == "Not None"
+    assert Maybe("Something").or_else_get("Nothing") == "Something"
+
+
+def test_maybe_or_else_raise():
+    with pytest.raises(ValueError):
+        assert Maybe(None).or_else_raise(lambda: ValueError("No value"))
+
+    assert Maybe("Something").or_else_raise(lambda: ValueError("No value")) == "Something"
+
+
+def test_maybe_map():
+    l = Maybe("lower")
+    lmapped = l.map(lambda s: s.upper())
+    assert lmapped == Maybe("LOWER")
+    assert lmapped == "LOWER"
+    assert lmapped.or_else_get("Nothing") == "LOWER"
+    assert lmapped.or_else(lambda: "Nothing") == "LOWER"
+    assert lmapped.or_else_raise(lambda: ValueError("Nothing!")) == "LOWER"
+
+
+def test_maybe_stream():
+    assert len(Maybe(None).stream().map(lambda v: v.upper()).to_list()) == 0
+    m = Maybe("lower").stream().map(lambda v: v.upper()).to_list()
+    assert len(m) == 1
+    assert m[0] == "LOWER"


### PR DESCRIPTION
Add a Maybe optional to make code handling `None` less painful. This Maybe object is modeled after the Java [`Optional`](https://docs.oracle.com/javase/8/docs/api/java/util/Optional.html) type added in Java 8.