### PR TITLE
Fix let* bindings to allow referencing previously bound names

### DIFF
--- a/tests/compiler_test.py
+++ b/tests/compiler_test.py
@@ -212,12 +212,16 @@ def test_interop_prop():
 def test_let():
     assert lcompile("(let* [a 1] a)") == 1
     assert lcompile("(let* [a :keyword b \"string\"] a)") == kw.keyword('keyword')
-    # TODO: fix the case which causes this test to pass
-    # assert lcompile("(let* [a :value b a] b)") == kw.keyword('value')
+    assert lcompile("(let* [a :value b a] b)") == kw.keyword('value')
+    assert lcompile("(let* [a 1 b :length c {b a} a 4] c)") == lmap.map({kw.keyword('length'): 1})
+    assert lcompile("(let* [a 1 b :length c {b a} a 4] a)") == 4
     assert lcompile("(let* [a \"lower\"] (.upper a))") == "LOWER"
 
     with pytest.raises(AttributeError):
         lcompile("(let* [a 'sym] c)")
+
+    with pytest.raises(compiler.CompilerException):
+        lcompile("(let* [] \"string\")")
 
 
 def test_quoted_list():


### PR DESCRIPTION
In #21, support was added to for `let*` bindings. Now, we have full support in `let*` bindings to refer to previously bound names and rebind names correctly.

Fixes #27 