### PR TITLE
Include column and line numbers during reading

### DIFF
--- a/basilisp/compiler.py
+++ b/basilisp/compiler.py
@@ -1,6 +1,7 @@
 import ast
 import collections
 import contextlib
+import functools
 import types
 import uuid
 from datetime import datetime
@@ -21,6 +22,7 @@ import basilisp.lang.set as lset
 import basilisp.lang.symbol as sym
 import basilisp.lang.util
 import basilisp.lang.vector as vec
+import basilisp.reader as reader
 from basilisp.lang.runtime import Var
 from basilisp.lang.typing import LispForm
 from basilisp.util import Maybe, munge
@@ -394,10 +396,20 @@ _INTERN_VAR_FN_NAME = _load_attr(f'{_VAR_ALIAS}.intern')
 _FIND_VAR_FN_NAME = _load_attr(f'{_VAR_ALIAS}.find')
 
 
+def _clean_meta(form: meta.Meta) -> Optional[meta.Meta]:
+    """Remove reader metadata from the form's meta map."""
+    meta = form.meta \
+        .discard(reader._READER_LINE_KW) \
+        .discard(reader._READER_COL_KW)
+    if len(meta) == 0:
+        return None
+    return meta
+
+
 def _meta_kwargs_ast(ctx: CompilerContext,
                      form: meta.Meta) -> ASTStream:
     if hasattr(form, 'meta') and form.meta is not None:
-        meta_nodes, meta = _nodes_and_expr(_to_ast(ctx, form.meta))
+        meta_nodes, meta = _nodes_and_expr(_to_ast(ctx, _clean_meta(form)))
         yield from meta_nodes
         yield _node(ast.keyword(arg='meta', value=_unwrap_node(meta)))
     else:
@@ -1116,6 +1128,28 @@ def _collection_literal_ast(ctx: CompilerContext,
             orig.flat_map(lambda x: x[1]).map(_unwrap_node).to_list())
 
 
+def _with_loc(f: ASTProcessor) -> ASTProcessor:
+    """Wrap a reader function in a decorator to supply line and column
+    information along with relevant forms."""
+
+    @functools.wraps(f)
+    def with_lineno_and_col(ctx: CompilerContext, form: LispForm) -> ASTStream:
+        try:
+            meta = form.meta
+            line = meta.get(reader._READER_LINE_KW)
+            col = meta.get(reader._READER_COL_KW)
+
+            for astnode in f(ctx, form):
+                astnode.node.lineno = line
+                astnode.node.col = col
+                yield astnode
+        except AttributeError:
+            yield from f(ctx, form)
+
+    return with_lineno_and_col
+
+
+@_with_loc
 def _to_ast(ctx: CompilerContext, form: LispForm) -> ASTStream:
     """Take a Lisp form as an argument and produce zero or more Python
     AST nodes.

--- a/basilisp/lang/list.py
+++ b/basilisp/lang/list.py
@@ -35,8 +35,8 @@ class List(ObjectProxy, Meta):
         return List(self.__wrapped__.cons(elem))
 
     @staticmethod
-    def empty() -> "List":
-        return l()
+    def empty(meta=None) -> "List":
+        return l(meta=meta)
 
 
 def list(members, meta=None) -> List:

--- a/basilisp/lang/map.py
+++ b/basilisp/lang/map.py
@@ -64,6 +64,12 @@ class Map(ObjectProxy, Meta):
             meta)
         return map(self.__wrapped__, meta=new_meta)
 
+    def discard(self, *ks) -> "Map":
+        m: PMap = self.__wrapped__
+        for k in ks:
+            m = m.discard(k)
+        return map(m)
+
     def update(self, *maps) -> "Map":
         m: PMap = self.__wrapped__.update(*maps)
         return map(m)

--- a/tests/reader_test.py
+++ b/tests/reader_test.py
@@ -356,44 +356,53 @@ def test_interop_prop():
 
 
 def test_meta():
+    def issubmap(m, sub):
+        for k, subv in sub.items():
+            try:
+                mv = m[k]
+                return subv == mv
+            except KeyError:
+                return False
+        return False
+
     s = read_str_first("^str s")
     assert s == sym.symbol('s')
-    assert s.meta == lmap.map({kw.keyword('tag'): sym.symbol('str')})
+    assert issubmap(s.meta, lmap.map({kw.keyword('tag'): sym.symbol('str')}))
 
     s = read_str_first("^:dynamic *ns*")
     assert s == sym.symbol('*ns*')
-    assert s.meta == lmap.map({kw.keyword('dynamic'): True})
+    assert issubmap(s.meta, lmap.map({kw.keyword('dynamic'): True}))
 
     s = read_str_first('^{:doc "If true, assert."} *assert*')
     assert s == sym.symbol('*assert*')
-    assert s.meta == lmap.map({kw.keyword('doc'): "If true, assert."})
+    assert issubmap(s.meta, lmap.map({kw.keyword('doc'): "If true, assert."}))
 
     v = read_str_first("^:has-meta [:a]")
     assert v == vec.v(kw.keyword('a'))
-    assert v.meta == lmap.map({kw.keyword('has-meta'): True})
+    assert issubmap(v.meta, lmap.map({kw.keyword('has-meta'): True}))
 
     l = read_str_first('^:has-meta (:a)')
     assert l == llist.l(kw.keyword('a'))
-    assert l.meta == lmap.map({kw.keyword('has-meta'): True})
+    assert issubmap(l.meta, lmap.map({kw.keyword('has-meta'): True}))
 
     m = read_str_first('^:has-meta {:key "val"}')
     assert m == lmap.map({kw.keyword('key'): "val"})
-    assert m.meta == lmap.map({kw.keyword('has-meta'): True})
+    assert issubmap(m.meta, lmap.map({kw.keyword('has-meta'): True}))
 
     t = read_str_first('^:has-meta #{:a}')
     assert t == lset.s(kw.keyword('a'))
-    assert t.meta == lmap.map({kw.keyword('has-meta'): True})
+    assert issubmap(t.meta, lmap.map({kw.keyword('has-meta'): True}))
 
     s = read_str_first('^:dynamic ^{:doc "If true, assert."} *assert*')
     assert s == sym.symbol('*assert*')
-    assert s.meta == lmap.map({
+    assert issubmap(s.meta, lmap.map({
         kw.keyword('dynamic'): True,
         kw.keyword('doc'): "If true, assert."
-    })
+    }))
 
     s = read_str_first('^{:always true} ^{:always false} *assert*')
     assert s == sym.symbol('*assert*')
-    assert s.meta == lmap.map({kw.keyword('always'): True})
+    assert issubmap(s.meta, lmap.map({kw.keyword('always'): True}))
 
 
 def test_invalid_meta_structure():

--- a/tests/reader_test.py
+++ b/tests/reader_test.py
@@ -23,16 +23,83 @@ def read_str_first(s, resolver: reader.Resolver = None):
 
 def test_stream_reader():
     sreader = reader.StreamReader(io.StringIO("12345"))
-    assert sreader.peek() == "1"
-    assert sreader.next_token() == "2"
-    assert sreader.peek() == "2"
+
+    assert "1" == sreader.peek()
+    assert (1, 1) == sreader.loc
+
+    assert "2" == sreader.next_token()
+    assert (1, 2) == sreader.loc
+
+    assert "2" == sreader.peek()
+    assert (1, 2) == sreader.loc
+
     sreader.pushback()
-    assert sreader.peek() == "1"
-    assert sreader.next_token() == "2"
-    assert sreader.next_token() == "3"
-    assert sreader.next_token() == "4"
-    assert sreader.next_token() == "5"
-    assert sreader.next_token() == ""
+    assert "1" == sreader.peek()
+    assert (1, 1) == sreader.loc
+
+    assert "2" == sreader.next_token()
+    assert (1, 2) == sreader.loc
+
+    assert "3" == sreader.next_token()
+    assert (1, 3) == sreader.loc
+
+    assert "4" == sreader.next_token()
+    assert (1, 4) == sreader.loc
+
+    assert "5" == sreader.next_token()
+    assert (1, 5) == sreader.loc
+
+    assert "" == sreader.next_token()
+    assert (1, 6) == sreader.loc
+
+
+def test_stream_reader_loc():
+    s = str(
+        "i=1\n"
+        "b=2\n"
+        "i"
+    )
+    sreader = reader.StreamReader(io.StringIO(s))
+
+    assert "i" == sreader.peek()
+    assert (1, 1) == sreader.loc
+
+    assert "=" == sreader.next_token()
+    assert (1, 2) == sreader.loc
+
+    assert "=" == sreader.peek()
+    assert (1, 2) == sreader.loc
+
+    sreader.pushback()
+    assert "i" == sreader.peek()
+    assert (1, 1) == sreader.loc
+
+    assert "=" == sreader.next_token()
+    assert (1, 2) == sreader.loc
+
+    assert "1" == sreader.next_token()
+    assert (1, 3) == sreader.loc
+
+    assert "\n" == sreader.next_token()
+    assert (2, 0) == sreader.loc
+
+    assert "b" == sreader.next_token()
+    assert (2, 1) == sreader.loc
+
+    assert "=" == sreader.next_token()
+    assert (2, 2) == sreader.loc
+
+    assert "2" == sreader.next_token()
+    assert (2, 3) == sreader.loc
+
+    assert "\n" == sreader.next_token()
+    assert (3, 0) == sreader.loc
+
+    assert "i" == sreader.next_token()
+    assert (3, 1) == sreader.loc
+
+    assert "" == sreader.next_token()
+    assert (3, 2) == sreader.loc
 
 
 def test_int():


### PR DESCRIPTION
This PR adds functionality to the reader to supply column and line number information as Lisp forms are read from a file. The compiler now supports reading that metadata from relevant forms and applying it to generated Python AST nodes.

That metadata allows Python to tag tracebacks along with the relevant Lisp code that generated the exception:

```
user=> (first '())

Traceback (most recent call last):
  File "/Users/christopher/Projects/basilisp/basilisp/main.py", line 44, in repl
    print(compiler.lrepr(eval_str(lsrc, ctx)))
  File "/Users/christopher/Projects/basilisp/basilisp/main.py", line 24, in eval_str
    last = compiler.compile_and_exec_form(form, ctx=ctx)
  File "/Users/christopher/Projects/basilisp/basilisp/compiler.py", line 1321, in compile_and_exec_form
    return _compile_and_exec_ast(module, expr_fn=wrapped_fn_name)
  File "/Users/christopher/Projects/basilisp/basilisp/compiler.py", line 1289, in _compile_and_exec_ast
    return getattr(mod, expr_fn)()
  File "<REPL Input>", line 1, in __lisp_expr__
  File "/Users/christopher/Projects/basilisp/basilisp/core/__init__.lpy", line 8, in first
    (fn* first [seq] (.-first seq)))
  File "/Users/christopher/.local/share/virtualenvs/basilisp-wildHrcW/lib/python3.6/site-packages/pyrsistent/_plist.py", line 275, in first
    raise AttributeError("Empty PList has no first")
AttributeError: Empty PList has no first
```

Fixes #24 