### PR TITLE
Don't throw exception for list without symbol first in macroexpansion

### DIFF
--- a/basilisp/compiler.py
+++ b/basilisp/compiler.py
@@ -600,7 +600,7 @@ def _assert_recur_is_tail(ctx: CompilerContext, form: lseq.Seq) -> None:  # noqa
     for i, child in enumerate(form):  # pylint:disable=too-many-nested-blocks
         listlen += 1
         if isinstance(child, (llist.List, lseq.Seq)):
-            if _is_sym_macro(ctx, child.first):
+            if isinstance(child.first, sym.Symbol) and _is_sym_macro(ctx, child.first):
                 continue
             elif child.first == _RECUR:
                 if first_recur_index is None:

--- a/tests/compiler_test.py
+++ b/tests/compiler_test.py
@@ -267,6 +267,10 @@ def test_fn_call(ns_var: Var):
     assert fvar == "bleep"
 
 
+def test_macro_expansion(ns_var: Var):
+    assert llist.l(1, 2, 3) == lcompile("((fn [] '(1 2 3)))")
+
+
 def test_if(ns_var: Var):
     assert lcompile("(if true :a :b)") == kw.keyword("a")
     assert lcompile("(if false :a :b)") == kw.keyword("b")


### PR DESCRIPTION
Fixes #131 