### PR TITLE
Demunge namespaces specified via Python import machinery

### DIFF
--- a/src/basilisp/importer.py
+++ b/src/basilisp/importer.py
@@ -9,6 +9,7 @@ from typing import Optional
 import basilisp.compiler as compiler
 import basilisp.lang.runtime as runtime
 import basilisp.reader as reader
+from basilisp.lang.util import demunge
 
 
 class BasilispImporter(MetaPathFinder, SourceLoader):
@@ -83,7 +84,8 @@ class BasilispImporter(MetaPathFinder, SourceLoader):
         # a blank module. If we do not replace the module here with the module we are
         # generating, then we will not be able to use advanced compilation features such
         # as direct Python variable access to functions and other def'ed values.
-        ns: runtime.Namespace = runtime.set_current_ns(fullname).value
+        ns_name = demunge(fullname)
+        ns: runtime.Namespace = runtime.set_current_ns(ns_name).value
         ns.module = module
 
         forms = reader.read_file(filename, resolver=runtime.resolve_alias)
@@ -95,7 +97,7 @@ class BasilispImporter(MetaPathFinder, SourceLoader):
         #
         # Later on, we can probably remove this and just use the 'ns macro to auto-refer
         # all 'basilisp.core values into the current namespace.
-        runtime.Namespace.add_default_import(fullname)
+        runtime.Namespace.add_default_import(ns_name)
 
 
 def hook_imports():

--- a/src/basilisp/lang/util.py
+++ b/src/basilisp/lang/util.py
@@ -5,7 +5,7 @@ import re
 import uuid
 from decimal import Decimal
 from fractions import Fraction
-from typing import Pattern
+from typing import Pattern, Match
 
 import dateutil.parser as dateparser
 
@@ -71,6 +71,24 @@ def munge(s: str, allow_builtins: bool = False) -> str:
         return f"{new_s}_"
 
     return new_s
+
+
+_DEMUNGE_PATTERN = re.compile(r"(__[A-Z]+__)")
+_DEMUNGE_REPLACEMENTS = {v: k for k, v in _MUNGE_REPLACEMENTS.items()}
+
+
+def demunge(s: str) -> str:
+    """Replace munged string components with their original
+    representation."""
+
+    def demunge_replacer(match: Match) -> str:
+        full_match = match.group(0)
+        replacement = _DEMUNGE_REPLACEMENTS.get(full_match, None)
+        if replacement:
+            return replacement
+        return full_match
+
+    return re.sub(_DEMUNGE_PATTERN, demunge_replacer, s).replace('_', '-')
 
 
 # Use an atomically incremented integer as a suffix for all

--- a/tests/basilisp/importer_test.py
+++ b/tests/basilisp/importer_test.py
@@ -1,7 +1,14 @@
+import importlib
+import os.path
 import sys
+import tempfile
 from unittest.mock import patch
 
+import _pytest.pytester as pytester
+
 import basilisp.importer as importer
+import basilisp.lang.runtime as runtime
+import basilisp.lang.symbol as sym
 
 
 def importer_counter():
@@ -22,3 +29,21 @@ def test_hook_imports():
         assert 1 == importer_counter()
         importer.hook_imports()
         assert 1 == importer_counter()
+
+
+def test_demunged_import(testdir: pytester.Testdir):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_module = os.path.join(tmpdir, 'long__AMP__namespace_name__PLUS__with___LT__punctuation__GT__.lpy')
+        with open(tmp_module, mode='w') as module:
+            code = """
+            (ns long&namespace-name+with-<punctuation>)
+            """
+            module.write(code)
+
+        with patch('sys.path', new=[tmpdir]), \
+             patch('sys.meta_path', new=[importer.BasilispImporter()]):
+            importlib.import_module('long__AMP__namespace_name__PLUS__with___LT__punctuation__GT__')
+
+        assert runtime.Namespace.get(sym.symbol('long&namespace-name+with-<punctuation>')) is not None
+        assert runtime.Namespace.get(
+            sym.symbol('long__AMP__namespace_name__PLUS__with___LT__punctuation__GT__')) is None

--- a/tests/basilisp/langutil_test.py
+++ b/tests/basilisp/langutil_test.py
@@ -1,0 +1,12 @@
+from basilisp.lang.util import demunge, _MUNGE_REPLACEMENTS
+
+
+def test_demunge():
+    for v, munged in _MUNGE_REPLACEMENTS.items():
+        assert demunge(munged) == v
+
+    assert "-->--" == demunge("____GT____")
+    assert "--init--" == demunge("__init__")
+    assert "random--V--" == demunge("random__V__")
+    assert "hi-how-are-you?" == demunge("hi_how_are_you__Q__")
+    assert "hi-how-are-you----" == demunge("hi_how_are_you____")

--- a/tests/basilisp/testrunner_test.py
+++ b/tests/basilisp/testrunner_test.py
@@ -1,11 +1,9 @@
 import _pytest.pytester as pytester
 
 
-# TODO: fix namespace after importer namespace issue resolved
-# (https://github.com/chrisrink10/basilisp/issues/206)
 def test_testrunner(testdir: pytester.Testdir):
     code = """
-    (ns test_fixture
+    (ns test-fixture
       (:require
        [basilisp.test :refer [deftest is]]))
 


### PR DESCRIPTION
Basilisp namespaces permit a wide range of punctuation marks which are not permitted in Python module or variable names. Basilisp hooks Python's import machinery to do much of the import work, so whenever a standard Python import is called with a munged Basilisp name, we used to generate the Namespace _with that munged name_. This led to orphaned Namespaces in the global Namespace cache and possibly inconsistent state.

This PR coerces imported Namespace names back to their Basilisp originals and generates the Namespace from that demunged name.

Fixes #206 