### PR TITLE
Add MyPy and Safety targets back to Tox for TravisCI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py36,py37,mypy,lint
 
 [travis]
 python =
-    3.6: py36, coverage, lint
+    3.6: py36, coverage, mypy, lint, safety
 
 [testenv]
 passenv = TRAVIS TRAVIS_*


### PR DESCRIPTION
Add `mypy` and `safety` targets back to Tox's config for TravisCI.