### PR TITLE
Allow more flexible interop property access syntax for macros

### DIFF
--- a/src/basilisp/lang/reader.py
+++ b/src/basilisp/lang/reader.py
@@ -389,12 +389,20 @@ def _read_interop(ctx: ReaderContext, end_token: str) -> llist.List:
     elif token == '-':
         reader.advance()
         seq.append(_INTEROP_PROP)
+
+        # If whitespace immediately follows, this is the form
+        # (.- object member ...), otherwise it is (.-member object ...).
+        # We need to support both, as the former is more commonly
+        # the format which will appear in macros.
         if whitespace_chars.match(reader.peek()):
-            raise SyntaxError(f"Expected Symbol; found whitespace")
-        member = _read_next_consuming_comment(ctx)
-        if not isinstance(member, symbol.Symbol):
-            raise SyntaxError(f"Expected Symbol; found {type(member)}")
-        instance = _read_next_consuming_comment(ctx)
+            instance = _read_next_consuming_comment(ctx)
+            member = _read_next_consuming_comment(ctx)
+        else:
+            member = _read_next_consuming_comment(ctx)
+            if not isinstance(member, symbol.Symbol):
+                raise SyntaxError(f"Expected Symbol; found {type(member)}")
+            instance = _read_next_consuming_comment(ctx)
+
         seq.append(instance)
         seq.append(member)
     else:

--- a/tests/basilisp/reader_test.py
+++ b/tests/basilisp/reader_test.py
@@ -586,13 +586,14 @@ def test_interop_call():
 
 
 def test_interop_prop():
-    assert read_str_first("(. sym -name)") == llist.l(
-        sym.symbol('.-'), sym.symbol('sym'), sym.symbol('name'))
-    assert read_str_first('(.-algorithm encoder)') == llist.l(
-        sym.symbol('.-'), sym.symbol('encoder'), sym.symbol('algorithm'))
-
-    with pytest.raises(reader.SyntaxError):
-        read_str_first('(.- name sym)')
+    assert llist.l(sym.symbol('.-'), sym.symbol('sym'), sym.symbol('name')
+                   ) == read_str_first("(. sym -name)")
+    assert llist.l(sym.symbol('.-'), sym.symbol('encoder'), sym.symbol('algorithm')
+                   ) == read_str_first('(.-algorithm encoder)')
+    assert llist.l(sym.symbol('.-'), sym.symbol('name'), sym.symbol('sym')
+                   ) == read_str_first('(.- name sym)')
+    assert llist.l(sym.symbol('.-'), sym.symbol('name'), "string"
+                   ) == read_str_first('(.- name "string")')
 
     with pytest.raises(reader.SyntaxError):
         read_str_first('(.-"string" sym)')


### PR DESCRIPTION
Fixes #275 