### PR TITLE
Emit compiler warning when Var and local names are shadowed

### DIFF
--- a/src/basilisp/cli.py
+++ b/src/basilisp/cli.py
@@ -51,10 +51,28 @@ def bootstrap_repl(which_ns: str) -> types.ModuleType:
 
 @cli.command(short_help='start the Basilisp REPL')
 @click.option('--default-ns', default=runtime._REPL_DEFAULT_NS, help='default namespace to use for the REPL')
-def repl(default_ns):
+@click.option('--use-var-indirection',
+              default=False,
+              is_flag=True,
+              envvar='BASILISP_USE_VAR_INDIRECTION',
+              help='if provided, all Var accesses will be performed via Var indirection')
+@click.option('--warn-on-shadowed-name',
+              default=False,
+              is_flag=True,
+              envvar='BASILISP_WARN_ON_SHADOWED_NAME',
+              help='if provided, emit warnings if a local name is shadowed by another local name')
+@click.option('--warn-on-shadowed-var',
+              default=True,
+              is_flag=True,
+              envvar='BASILISP_WARN_ON_SHADOWED_VAR',
+              help='if provided, emit warnings if a Var name is shadowed by a local name')
+def repl(default_ns, use_var_indirection, warn_on_shadowed_name, warn_on_shadowed_var):
     basilisp.init()
     repl_module = bootstrap_repl(default_ns)
-    ctx = compiler.CompilerContext()
+    ctx = compiler.CompilerContext(
+        {compiler.USE_VAR_INDIRECTION: use_var_indirection,
+         compiler.WARN_ON_SHADOWED_NAME: warn_on_shadowed_name,
+         compiler.WARN_ON_SHADOWED_VAR: warn_on_shadowed_var})
     ns_var = runtime.set_current_ns(default_ns)
     eof = object()
     while True:
@@ -95,10 +113,33 @@ def repl(default_ns):
 @click.argument('file-or-code')
 @click.option('-c', '--code', is_flag=True, help='if provided, treat argument as a string of code')
 @click.option('--in-ns', default=runtime._REPL_DEFAULT_NS, help='namespace to use for the code')
-def run(file_or_code, code, in_ns):
+@click.option('--use-var-indirection',
+              default=False,
+              is_flag=True,
+              envvar='BASILISP_USE_VAR_INDIRECTION',
+              help='if provided, all Var accesses will be performed via Var indirection')
+@click.option('--warn-on-shadowed-name',
+              default=False,
+              is_flag=True,
+              envvar='BASILISP_WARN_ON_SHADOWED_NAME',
+              help='if provided, emit warnings if a local name is shadowed by another local name')
+@click.option('--warn-on-shadowed-var',
+              default=True,
+              is_flag=True,
+              envvar='BASILISP_WARN_ON_SHADOWED_VAR',
+              help='if provided, emit warnings if a Var name is shadowed by a local name')
+def run(file_or_code,  # pylint: disable=too-many-arguments
+        code,
+        in_ns,
+        use_var_indirection,
+        warn_on_shadowed_name,
+        warn_on_shadowed_var):
     """Run a Basilisp script or a line of code, if it is provided."""
     basilisp.init()
-    ctx = compiler.CompilerContext()
+    ctx = compiler.CompilerContext(
+        {compiler.USE_VAR_INDIRECTION: use_var_indirection,
+         compiler.WARN_ON_SHADOWED_NAME: warn_on_shadowed_name,
+         compiler.WARN_ON_SHADOWED_VAR: warn_on_shadowed_var})
     eof = object()
 
     with runtime.ns_bindings(in_ns) as ns:

--- a/src/basilisp/lang/compiler.py
+++ b/src/basilisp/lang/compiler.py
@@ -14,7 +14,7 @@ from decimal import Decimal
 from enum import Enum
 from fractions import Fraction
 from itertools import chain
-from typing import (Dict, Iterable, Pattern, Tuple, Optional, List, Union, Callable, Mapping, NamedTuple, cast, Deque,
+from typing import (Dict, Iterable, Pattern, Tuple, Optional, List, Union, Callable, NamedTuple, cast, Deque,
                     Any)
 
 import astor.code_gen as codegen
@@ -166,10 +166,6 @@ class CompilerContext:
         return runtime.get_current_ns()
 
     @property
-    def opts(self) -> Mapping[str, bool]:
-        return self._opts  # type: ignore
-
-    @property
     def use_var_indirection(self) -> bool:
         """If True, compile all variable references using Var.find indirection."""
         return self._opts.entry(USE_VAR_INDIRECTION, False)
@@ -234,11 +230,6 @@ class CompilerContext:
 
 class CompilerException(Exception):
     pass
-
-
-def _assertl(c: bool, msg=None):
-    if not c:
-        raise CompilerException(msg)
 
 
 def _load_attr(name: str) -> ast.Attribute:
@@ -467,35 +458,23 @@ _SYM_REDEF_META_KEY = kw.keyword("redef")
 def _is_dynamic(v: Var) -> bool:
     """Return True if the Var holds a value which should be compiled to a dynamic
     Var access."""
-    try:
-        return Maybe(v.meta).map(
-            lambda m: m.get(_SYM_DYNAMIC_META_KEY, None)  # type: ignore
-        ).or_else_get(
-            False)
-    except (KeyError, AttributeError):
-        return False
+    return Maybe(v.meta).map(
+        lambda m: m.get(_SYM_DYNAMIC_META_KEY, None)  # type: ignore
+    ).or_else_get(False)
 
 
 def _is_macro(v: Var) -> bool:
     """Return True if the Var holds a macro function."""
-    try:
-        return Maybe(v.meta).map(
-            lambda m: m.get(_SYM_MACRO_META_KEY, None)  # type: ignore
-        ).or_else_get(
-            False)
-    except (KeyError, AttributeError):
-        return False
+    return Maybe(v.meta).map(
+        lambda m: m.get(_SYM_MACRO_META_KEY, None)  # type: ignore
+    ).or_else_get(False)
 
 
 def _is_redefable(v: Var) -> bool:
     """Return True if the Var can be redefined."""
-    try:
-        return Maybe(v.meta).map(
-            lambda m: m.get(_SYM_REDEF_META_KEY, None)  # type: ignore
-        ).or_else_get(
-            False)
-    except (KeyError, AttributeError):
-        return False
+    return Maybe(v.meta).map(
+        lambda m: m.get(_SYM_REDEF_META_KEY, None)  # type: ignore
+    ).or_else_get(False)
 
 
 def _new_symbol(ctx: CompilerContext,  # pylint: disable=too-many-arguments
@@ -1705,8 +1684,7 @@ def _sym_ast(ctx: CompilerContext, form: sym.Symbol) -> ASTStream:
 
     if st_sym is not None:
         munged, sym_ctx, _ = st_sym
-        if munged is None:
-            raise ValueError(f"Lisp symbol '{form}' not found in {repr(st)}")
+        assert munged is not None, f"Lisp symbol '{form}' not found in symbol table"
 
         if sym_ctx == _SYM_CTX_LOCAL:
             yield _node(ast.Name(id=munged, ctx=ast.Load()))

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ setenv =
 deps =
     six==1.10.0
 commands =
-    pytest
+    pytest {posargs}
 
 [testenv:coverage]
 deps =


### PR DESCRIPTION
Fixes #240 
Fixes #294 