### PR TITLE
Allow Python imports to be aliased like a Basilisp require

### DIFF
--- a/src/basilisp/core/__init__.lpy
+++ b/src/basilisp/core/__init__.lpy
@@ -1166,7 +1166,8 @@
   (py-time/perf-counter))
 
 (defmacro time
-  ""
+  "Time the execution of expr. Return the result of expr and print the
+  time execution took in milliseconds."
   [expr]
   `(let [start (perf-counter)]
      (try

--- a/src/basilisp/core/__init__.lpy
+++ b/src/basilisp/core/__init__.lpy
@@ -1159,6 +1159,21 @@
        (finally
          (. (var ~vvar) ~'pop-bindings)))))
 
+(import* [time :as py-time])
+
+(defn ^:private perf-counter
+  []
+  (py-time/perf-counter))
+
+(defmacro time
+  ""
+  [expr]
+  `(let [start (perf-counter)]
+     (try
+       ~expr
+       (finally
+         (println (* 1000 (- (perf-counter) start)) "msecs")))))
+
 ;;;;;;;;;;;;;;;;;;;;;;
 ;; Threading Macros ;;
 ;;;;;;;;;;;;;;;;;;;;;;

--- a/src/basilisp/lang/compiler.py
+++ b/src/basilisp/lang/compiler.py
@@ -2083,7 +2083,9 @@ def _resolve_sym(ctx: CompilerContext, form: sym.Symbol) -> Optional[str]:  # no
 
             # Otherwise, try to direct-link it like a Python variable
             safe_module_name = munge(module_name.name)
-            assert safe_module_name in sys.modules, f"Module '{safe_module_name}' is not imported"
+            assert (
+                safe_module_name in sys.modules
+            ), f"Module '{safe_module_name}' is not imported"
             ns_module = sys.modules[safe_module_name]
             safe_ns = munge(form.ns)
 

--- a/tests/basilisp/compiler_test.py
+++ b/tests/basilisp/compiler_test.py
@@ -593,6 +593,24 @@ def test_truthiness(ns: runtime.Namespace):
     assert kw.keyword("a") == lcompile("(if #{true} :a :b)")
 
 
+def test_import(ns: runtime.Namespace):
+    with pytest.raises(compiler.CompilerException):
+        lcompile("(import* :time)")
+
+    with pytest.raises(compiler.CompilerException):
+        lcompile('(import* "time")')
+
+    with pytest.raises(ImportError):
+        lcompile("(import* real.fake.module)")
+
+    import time
+
+    assert time.perf_counter == lcompile("(import* time) time/perf-counter")
+    assert time.perf_counter == lcompile(
+        "(import* [time :as py-time]) py-time/perf-counter"
+    )
+
+
 def test_interop_new(ns: runtime.Namespace):
     assert "hi" == lcompile('(builtins.str. "hi")')
     assert "1" == lcompile("(builtins.str. 1)")


### PR DESCRIPTION
Fixes #44 