### PR TITLE
Remove superfluous functional.seq calls

### DIFF
--- a/src/basilisp/lang/map.py
+++ b/src/basilisp/lang/map.py
@@ -1,3 +1,4 @@
+from builtins import map as pymap
 from collections import Sequence
 from typing import Optional  # noqa # pylint: disable=unused-import
 
@@ -225,5 +226,5 @@ def from_entries(entries):
 
 
 def hash_map(*pairs) -> Map:
-    entries = seq(partition(pairs, 2)).map(lambda v: MapEntry.of(v[0], v[1])).to_list()
+    entries = pymap(lambda v: MapEntry.of(v[0], v[1]), partition(pairs, 2))
     return from_entries(entries)

--- a/src/basilisp/lang/obj.py
+++ b/src/basilisp/lang/obj.py
@@ -73,7 +73,7 @@ class LispObject(ABC):
         else:
             items = iterable
 
-        items = seq(items).map(lambda o: lrepr(o, **kwargs)).to_list()
+        items = list(map(lambda o: lrepr(o, **kwargs), items))
         seq_lrepr = PRINT_SEPARATOR.join(items + trailer)
 
         print_meta = kwargs["print_meta"]

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -9,8 +9,6 @@ import types
 from fractions import Fraction
 from typing import Optional, Dict, Tuple
 
-from functional import seq
-
 import basilisp.lang.associative as lassoc
 import basilisp.lang.collection as lcoll
 import basilisp.lang.deref as lderef
@@ -274,7 +272,8 @@ class Namespace:
 
     DEFAULT_IMPORTS = atom.Atom(
         lset.set(
-            seq(
+            map(
+                sym.symbol,
                 [
                     "builtins",
                     "io",
@@ -295,10 +294,8 @@ class Namespace:
                     "basilisp.lang.symbol",
                     "basilisp.lang.vector",
                     "basilisp.lang.util",
-                ]
+                ],
             )
-            .map(sym.symbol)
-            .to_list()
         )
     )
     GATED_IMPORTS = lset.set(["basilisp.core"])
@@ -322,9 +319,12 @@ class Namespace:
         self._aliases: atom.Atom = atom.Atom(lmap.Map.empty())
         self._imports: atom.Atom = atom.Atom(
             lmap.map(
-                seq(Namespace.DEFAULT_IMPORTS.deref())
-                .map(lambda s: (s, importlib.import_module(s.name)))
-                .to_dict()
+                dict(
+                    map(
+                        lambda s: (s, importlib.import_module(s.name)),
+                        Namespace.DEFAULT_IMPORTS.deref(),
+                    )
+                )
             )
         )
         self._import_aliases: atom.Atom = atom.Atom(lmap.Map.empty())

--- a/src/basilisp/lang/vector.py
+++ b/src/basilisp/lang/vector.py
@@ -18,6 +18,9 @@ class Vector(Associative, Collection, LispObject, Meta, Seqable):
         self._inner = wrapped
         self._meta = meta
 
+    def __contains__(self, item):
+        return item in self._inner
+
     def __eq__(self, other):
         return self._inner == other
 

--- a/src/basilisp/testrunner.py
+++ b/src/basilisp/testrunner.py
@@ -128,9 +128,9 @@ class BasilispTestItem(pytest.Item):
     The BasilispTestItem collects all the failures and returns a report
     to PyTest to show to the end-user."""
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
-        name: str,  # pylint: disable=too-many-arguments
+        name: str,
         parent: BasilispFile,
         run_test: TestFunction,
         namespace: str,

--- a/tests/basilisp/vector_test.py
+++ b/tests/basilisp/vector_test.py
@@ -53,6 +53,15 @@ def test_contains():
     assert False is vector.Vector.empty().contains(-1)
 
 
+def test_py_contains():
+    assert "a" in vector.v("a")
+    assert "a" in vector.v("a", "b")
+    assert "b" in vector.v("a", "b")
+    assert "c" not in vector.Vector.empty()
+    assert "c" not in vector.v("a")
+    assert "c" not in vector.v("a", "b")
+
+
 def test_vector_cons():
     meta = lmap.m(tag="async")
     v1 = vector.v(keyword("kw1"), meta=meta)


### PR DESCRIPTION
Remove some superfluous `functional.seq` calls which were equivalent to the builtin `map` function.