### PR TITLE
Use a mutable dict for lrepr kwargs

### DIFF
--- a/src/basilisp/lang/obj.py
+++ b/src/basilisp/lang/obj.py
@@ -119,16 +119,14 @@ def lrepr(  # pylint: disable=too-many-arguments
     runtime to the basilisp.core dynamic variables which correspond to each
     of the keyword arguments to this function. To use a version of lrepr
     which does capture those values, call basilisp.lang.runtime.lrepr directly."""
-    kwargs = pmap(
-        {
-            "human_readable": human_readable,
-            "print_dup": print_dup,
-            "print_length": print_length,
-            "print_level": print_level,
-            "print_meta": print_meta,
-            "print_readably": print_readably,
-        }
-    )
+    kwargs = {
+        "human_readable": human_readable,
+        "print_dup": print_dup,
+        "print_length": print_length,
+        "print_level": print_level,
+        "print_meta": print_meta,
+        "print_readably": print_readably,
+    }
     if isinstance(o, LispObject):
         return o._lrepr(**kwargs)
     elif o is True:


### PR DESCRIPTION
Using a mutable `dict` rather than a `PMap` seems to speed up the test suite (and, likely, non-test code) by _a lot_. No surprise there.