### PR TITLE
Improve Coverage by ignoring certain unimportant lines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ test-pypy:
 		pypy:3.6-7.0-slim-jessie \
 		/bin/sh -c 'cd /usr/src/app && pip install tox && tox -e pypy3'
 
+
 .PHONY: pypy-shell
 pypy-shell:
 	@docker run -it \

--- a/src/basilisp/util.py
+++ b/src/basilisp/util.py
@@ -1,38 +1,9 @@
 import contextlib
-import functools
-import inspect
-import os.path
 import time
 from typing import Optional, Callable, TypeVar, Generic
 
 from functional import seq
 from functional.pipeline import Sequence
-
-from basilisp.lang.obj import lrepr
-
-
-def trace(f):
-    @functools.wraps(f)
-    def wrapper(*args, **kwargs):
-        calling_frame = inspect.getframeinfo(inspect.stack()[1][0])
-        filename = os.path.relpath(calling_frame.filename)
-        lineno = calling_frame.lineno
-        strargs = ", ".join(map(repr, args))
-        strkwargs = ", ".join([f"{lrepr(k)}={lrepr(v)}" for k, v in kwargs.items()])
-
-        try:
-            ret = f(*args, **kwargs)
-            print(
-                f"[{filename}:{lineno}] {f.__name__}({strargs}, {strkwargs}) => {ret}"
-            )
-            return ret
-        except Exception as e:
-            print(
-                f"[{filename}:{lineno}] {f.__name__}({strargs}, {strkwargs}) => raised {type(e)}"
-            )
-            raise e
-
-    return wrapper
 
 
 @contextlib.contextmanager

--- a/src/basilisp/walker.py
+++ b/src/basilisp/walker.py
@@ -1,4 +1,5 @@
 from functools import partial
+
 import basilisp.lang.list as llist
 import basilisp.lang.map as lmap
 import basilisp.lang.set as lset
@@ -29,14 +30,14 @@ def prewalk(f, form):
     return walk(inner_f, lambda x: x, f(form))
 
 
-def _print_identity(v):
+def _print_identity(v):  # pragma: no cover
     print(v)
     return v
 
 
-def postwalk_demo(form):
+def postwalk_demo(form):  # pragma: no cover
     return postwalk(_print_identity, form)
 
 
-def prewalk_demo(form):
+def prewalk_demo(form):  # pragma: no cover
     return prewalk(_print_identity, form)

--- a/tests/basilisp/lrepr_test.py
+++ b/tests/basilisp/lrepr_test.py
@@ -8,13 +8,15 @@ import basilisp.lang.compiler as compiler
 import basilisp.lang.reader as reader
 import basilisp.lang.runtime as runtime
 
+COMPILER_FILE_PATH = "lrepr_test"
+
 
 def lcompile(s: str):
     """Compile and execute the code in the input string.
 
     Return the resulting expression."""
-    ctx = compiler.CompilerContext()
-    mod = runtime._new_module("lrepr_test")
+    ctx = compiler.CompilerContext(COMPILER_FILE_PATH)
+    mod = runtime._new_module(COMPILER_FILE_PATH)
 
     last = None
     for form in reader.read_str(s):

--- a/tox.ini
+++ b/tox.ini
@@ -35,11 +35,27 @@ commands =
     coverage report
     coveralls
 
+[coverage:run]
+branch = True
+omit =
+    */__version__.py
+
 [coverage:paths]
 source =
    src/basilisp
    .tox/*/lib/python*/site-packages/basilisp
    .tox/pypy*/site-packages/basilisp
+
+[coverage:report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    if self\.debug
+    raise AssertionError
+    raise NotImplementedError
+    if 0:
+    if __name__ == .__main__.:
 
 [testenv:format]
 parallel_show_output = {env:TOX_SHOW_OUTPUT:false}


### PR DESCRIPTION
Certain lines that aren't (or can't) covered in standard tests can cause deflated Coverage metrics, so this PR excludes those lines.