### PR TITLE
Allow users to disable emitting Python AST strings

### DIFF
--- a/src/basilisp/importer.py
+++ b/src/basilisp/importer.py
@@ -263,7 +263,7 @@ class BasilispImporter(MetaPathFinder, SourceLoader):
 
         # Check if a valid, cached version of this Basilisp namespace exists and, if so,
         # load it and bypass the expensive compilation process below.
-        if os.getenv(_NO_CACHE_ENVVAR, None) == "True":
+        if os.getenv(_NO_CACHE_ENVVAR, None) == "true":
             self._exec_module(fullname, spec.loader_state, path_stats, module)
         else:
             try:

--- a/src/basilisp/lang/compiler/__init__.py
+++ b/src/basilisp/lang/compiler/__init__.py
@@ -67,7 +67,7 @@ class CompilerContext:
         return self._optimizer
 
 
-def _emit_ast_string(module: ast.AST) -> None:
+def _emit_ast_string(module: ast.AST) -> None:  # pragma: no cover
     """Emit the generated Python AST string either to standard out or to the
     *generated-python* dynamic Var for the current namespace. If the
     BASILISP_EMIT_GENERATED_PYTHON env var is not set True, this method is a
@@ -79,7 +79,7 @@ def _emit_ast_string(module: ast.AST) -> None:
         return
 
     if runtime.print_generated_python():
-        print(to_py_str(module))  # pragma: no cover
+        print(to_py_str(module))
     else:
         runtime.add_generated_python(to_py_str(module))
 

--- a/src/basilisp/lang/compiler/__init__.py
+++ b/src/basilisp/lang/compiler/__init__.py
@@ -1,29 +1,30 @@
 import ast
 import itertools
+import os
 import types
-from typing import Optional, Callable, Any, Iterable, List, Dict
+from typing import Any, Callable, Dict, Iterable, List, Optional
 
 from astor import code_gen as codegen
 
 import basilisp.lang.runtime as runtime
 from basilisp.lang.compiler.exception import CompilerException, CompilerPhase  # noqa
 from basilisp.lang.compiler.generator import (  # noqa
-    GeneratorContext,
     GeneratedPyAST,
+    GeneratorContext,
+    USE_VAR_INDIRECTION,
+    WARN_ON_VAR_INDIRECTION,
     expressionize as _expressionize,
     gen_py_ast,
     py_module_preamble,
     statementize as _statementize,
-    USE_VAR_INDIRECTION,
-    WARN_ON_VAR_INDIRECTION,
 )
 from basilisp.lang.compiler.optimizer import PythonASTOptimizer
 from basilisp.lang.compiler.parser import (  # noqa
     ParserContext,
-    parse_ast,
     WARN_ON_SHADOWED_NAME,
     WARN_ON_SHADOWED_VAR,
     WARN_ON_UNUSED_NAMES,
+    parse_ast,
 )
 from basilisp.lang.typing import ReaderForm
 from basilisp.lang.util import genname
@@ -66,6 +67,23 @@ class CompilerContext:
         return self._optimizer
 
 
+def _emit_ast_string(module: ast.AST) -> None:
+    """Emit the generated Python AST string either to standard out or to the
+    *generated-python* dynamic Var for the current namespace. If the
+    BASILISP_EMIT_GENERATED_PYTHON env var is not set True, this method is a
+    no-op."""
+    # TODO: eventually, this default should become "false" but during this
+    #       period of heavy development, having it set to "true" by default
+    #       is tremendously useful
+    if os.getenv("BASILISP_EMIT_GENERATED_PYTHON", "true") != "true":
+        return
+
+    if runtime.print_generated_python():
+        print(to_py_str(module))  # pragma: no cover
+    else:
+        runtime.add_generated_python(to_py_str(module))
+
+
 def compile_and_exec_form(  # pylint: disable= too-many-arguments
     form: ReaderForm,
     ctx: CompilerContext,
@@ -102,10 +120,7 @@ def compile_and_exec_form(  # pylint: disable= too-many-arguments
     ast_module = ctx.py_ast_optimizer.visit(ast_module)
     ast.fix_missing_locations(ast_module)
 
-    if runtime.print_generated_python():
-        print(to_py_str(ast_module))  # pragma: no cover
-    else:
-        runtime.add_generated_python(to_py_str(ast_module))
+    _emit_ast_string(ast_module)
 
     bytecode = compile(ast_module, ctx.filename, "exec")
     if collect_bytecode:
@@ -135,10 +150,7 @@ def _incremental_compile_module(
     module = optimizer.visit(module)
     ast.fix_missing_locations(module)
 
-    if runtime.print_generated_python():
-        print(to_py_str(module))  # pragma: no cover
-    else:
-        runtime.add_generated_python(to_py_str(module))
+    _emit_ast_string(module)
 
     bytecode = compile(module, source_filename, "exec")
     if collect_bytecode:

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py36,py37,mypy,format,lint
 parallel_show_output = {env:TOX_SHOW_OUTPUT:false}
 passenv = TRAVIS TRAVIS_*
 setenv =
-    BASILISP_DO_NOT_CACHE_NAMESPACES = True
+    BASILISP_DO_NOT_CACHE_NAMESPACES = true
 whitelist_externals = rm
 deps =
     coverage


### PR DESCRIPTION
Emitting the generated Python AST to strings and then to stdout or `*generated-python*` Var adds a bit of time to startup, which is a fine price to pay during development, but would be more onerous to normal users. This PR creates an environment var `BASILISP_EMIT_GENERATED_PYTHON` which can be set to disable the emission of generated Python. Eventually, the default value will switch to `false` (when development settles down), but for now having `true` set as the default value is tremendously useful.