### PR TITLE
Clean up the interface hierarchy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 88
-py36 = true
+target-version = ['py36']
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/src/basilisp/core/__init__.lpy
+++ b/src/basilisp/core/__init__.lpy
@@ -621,9 +621,15 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn deref
-  "Dereference a delay or atom and returns its contents."
-  [o]
-  (basilisp.lang.runtime/deref o))
+  "Dereference a delay or atom and returns its contents.
+  If o is an object implementing IBlockingDeref and timeout-s and
+  timeout-val are supplied, deref will wait at most timeout-s seconds,
+  returning timeout-val if timeout-s seconds elapse and o has not
+  returned."
+  ([o]
+   (basilisp.lang.runtime/deref o))
+  ([o timeout-s timeout-val]
+   (basilisp.lang.runtime/deref o timeout-s timeout-val)))
 
 (defn compare-and-set!
   "Atomically set the value of atom to new-val if and only if old-val

--- a/src/basilisp/lang/delay.py
+++ b/src/basilisp/lang/delay.py
@@ -13,12 +13,12 @@ T = TypeVar("T")
 @attr.s(
     auto_attribs=True,
     frozen=True,
-    these={"f": attr.ib(), "value": attr.ib(), "computed": attr.ib()},
+    these={"f": attr.ib(), "value": attr.ib(), "computed": attr.ib(default=False)},
 )
 class _DelayState(Generic[T]):
     f: Callable[[], T]
     value: Optional[T]
-    computed: bool = False
+    computed: bool
 
 
 class Delay(IDeref[T]):

--- a/src/basilisp/lang/interfaces.py
+++ b/src/basilisp/lang/interfaces.py
@@ -4,26 +4,6 @@ from typing import AbstractSet, Generic, Iterable, Mapping, Optional, Sequence, 
 
 from basilisp.lang.obj import LispObject as _LispObject, seq_lrepr
 
-K = TypeVar("K")
-V = TypeVar("V")
-
-
-class IAssociative(Mapping[K, V]):
-    __slots__ = ()
-
-    @abstractmethod
-    def assoc(self, *kvs) -> "IAssociative[K, V]":
-        raise NotImplementedError()
-
-    @abstractmethod
-    def contains(self, k: K) -> bool:
-        raise NotImplementedError()
-
-    @abstractmethod
-    def entry(self, k: K, default: Optional[V] = None) -> Optional[V]:
-        raise NotImplementedError()
-
-
 T = TypeVar("T")
 
 
@@ -32,6 +12,16 @@ class IDeref(Generic[T]):
 
     @abstractmethod
     def deref(self) -> Optional[T]:
+        raise NotImplementedError()
+
+
+class IBlockingDeref(IDeref[T]):
+    __slots__ = ()
+
+    @abstractmethod
+    def deref(
+        self, timeout: Optional[float] = None, timeout_val: Optional[T] = None
+    ) -> Optional[T]:
         raise NotImplementedError()
 
 
@@ -46,6 +36,10 @@ class IExceptionInfo(Exception):
     @abstractmethod
     def data(self) -> "IPersistentMap":
         raise NotImplementedError()
+
+
+K = TypeVar("K")
+V = TypeVar("V")
 
 
 class IMapEntry(Generic[K, V]):
@@ -78,7 +72,15 @@ class IMeta(ABC):
 ILispObject = _LispObject
 
 
-class IPersistentCollection(Generic[T]):
+class ISeqable(Iterable[T]):
+    __slots__ = ()
+
+    @abstractmethod
+    def seq(self) -> "ISeq[T]":
+        raise NotImplementedError()
+
+
+class IPersistentCollection(ISeqable[T]):
     __slots__ = ()
 
     @abstractmethod
@@ -88,6 +90,22 @@ class IPersistentCollection(Generic[T]):
     @staticmethod
     @abstractmethod
     def empty() -> "IPersistentCollection[T]":
+        raise NotImplementedError()
+
+
+class IAssociative(Mapping[K, V], IPersistentCollection[IMapEntry[K, V]]):
+    __slots__ = ()
+
+    @abstractmethod
+    def assoc(self, *kvs) -> "IAssociative[K, V]":
+        raise NotImplementedError()
+
+    @abstractmethod
+    def contains(self, k: K) -> bool:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def entry(self, k: K, default: Optional[V] = None) -> Optional[V]:
         raise NotImplementedError()
 
 
@@ -123,17 +141,31 @@ class IPersistentSet(AbstractSet[T], IPersistentCollection[T]):
         raise NotImplementedError()
 
 
+# MyPy has a lot of trouble dealing with the fact that Vectors are
+# considered as mapping types (from int -> T) and more traditional
+# sequential collections since the Python supertypes signatures conflict.
+# Below, we override the supertype signatures to select the signature
+# we specifically want to appear, but MyPy still complains. For now,
+# we will simply silence MyPy.
 class IPersistentVector(  # type: ignore
-    IAssociative[int, T], IPersistentStack[T], Sequence[T]
+    Sequence[T], IAssociative[int, T], IPersistentStack[T]
 ):
     __slots__ = ()
+
+    @abstractmethod
+    def cons(self, *elems: T) -> "IPersistentVector[T]":  # type: ignore
+        raise NotImplementedError()
+
+    @abstractmethod
+    def seq(self) -> "ISeq[T]":  # type: ignore
+        raise NotImplementedError()
 
 
 class IRecord(ABC):
     __slots__ = ()
 
 
-class ISeq(ILispObject, Iterable[T]):
+class ISeq(ILispObject, ISeqable[T]):
     __slots__ = ()
 
     @property
@@ -155,6 +187,9 @@ class ISeq(ILispObject, Iterable[T]):
     def cons(self, elem: T) -> "ISeq[T]":
         raise NotImplementedError()
 
+    def seq(self) -> "ISeq[T]":
+        return self
+
     def _lrepr(self, **kwargs):
         return seq_lrepr(iter(self), "(", ")", **kwargs)
 
@@ -172,13 +207,6 @@ class ISeq(ILispObject, Iterable[T]):
         while o:
             yield o.first
             o = o.rest
-
-
-class ISeqable(ABC, Iterable[T]):
-    __slots__ = ()
-
-    def seq(self) -> ISeq[T]:
-        raise NotImplementedError()
 
 
 class IType(ABC):

--- a/src/basilisp/lang/list.py
+++ b/src/basilisp/lang/list.py
@@ -85,9 +85,13 @@ class List(IMeta, ISeq[T], IPersistentList[T]):  # type: ignore
 
 def list(members, meta=None) -> List:  # pylint:disable=redefined-builtin
     """Creates a new list."""
-    return List(plist(iterable=members), meta=meta)
+    return List(  # pylint: disable=abstract-class-instantiated
+        plist(iterable=members), meta=meta
+    )
 
 
 def l(*members, meta=None) -> List:
     """Creates a new list from members."""
-    return List(plist(iterable=members), meta=meta)
+    return List(  # pylint: disable=abstract-class-instantiated
+        plist(iterable=members), meta=meta
+    )

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -983,11 +983,6 @@ def get(m, k, default=None):
         return default
 
 
-def is_special_form(s: sym.Symbol) -> bool:
-    """Return True if s names a special form."""
-    return s in _SPECIAL_FORMS
-
-
 @functools.singledispatch
 def to_lisp(o, keywordize_keys: bool = True):
     """Recursively convert Python collections into Lisp collections."""
@@ -1245,7 +1240,6 @@ def _basilisp_fn(f):
     """Create a Basilisp function, setting meta and supplying a with_meta
     method implementation."""
     assert not hasattr(f, "meta")
-    f._basilisp_fn = True
     f.meta = None
     f.with_meta = partial(_fn_with_meta, f)
     return f

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -828,8 +828,7 @@ def apply_kw(f, args):
     except TypeError as e:
         logger.debug("Ignored %s: %s", type(e).__name__, e)
 
-    kwargs = to_py(last, lambda kw: munge(kw.name))
-    return f(*final, **kwargs)
+    return f(*final, **last)
 
 
 __nth_sentinel = object()

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -43,7 +43,6 @@ from basilisp.lang.interfaces import (
     ISeqable,
 )
 from basilisp.lang.typing import LispNumber
-from basilisp.lang.util import munge
 from basilisp.logconfig import TRACE
 from basilisp.util import Maybe
 

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -9,7 +9,17 @@ import re
 import threading
 import types
 from fractions import Fraction
-from typing import Any, Callable, Dict, Iterable, Optional, Tuple, Union
+from typing import (
+    AbstractSet,
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    Mapping,
+    Optional,
+    Tuple,
+    Union,
+)
 
 import basilisp.lang.keyword as kw
 import basilisp.lang.list as llist
@@ -22,12 +32,18 @@ import basilisp.lang.vector as vec
 from basilisp.lang.atom import Atom
 from basilisp.lang.interfaces import (
     IAssociative,
+    IBlockingDeref,
     IDeref,
     IPersistentCollection,
+    IPersistentList,
+    IPersistentMap,
+    IPersistentSet,
+    IPersistentVector,
     ISeq,
     ISeqable,
 )
 from basilisp.lang.typing import LispNumber
+from basilisp.lang.util import munge
 from basilisp.logconfig import TRACE
 from basilisp.util import Maybe
 
@@ -613,7 +629,7 @@ class Namespace:
             }
         )
 
-        candidates = filter(  # type: ignore
+        candidates = filter(
             Namespace.__completion_matcher(prefix), itertools.chain(aliases, imports)
         )
         if name_in_module is not None:
@@ -812,7 +828,8 @@ def apply_kw(f, args):
     except TypeError as e:
         logger.debug("Ignored %s: %s", type(e).__name__, e)
 
-    return f(*final, **last)
+    kwargs = to_py(last, lambda kw: munge(kw.name))
+    return f(*final, **kwargs)
 
 
 __nth_sentinel = object()
@@ -900,10 +917,17 @@ def partial(f, *args):
     return partial_f
 
 
-def deref(o):
-    """Dereference a Deref object and return its contents."""
+def deref(o, timeout_s=None, timeout_val=None):
+    """Dereference a Deref object and return its contents.
+
+    If o is an object implementing IBlockingDeref and timeout_s and
+    timeout_val are supplied, deref will wait at most timeout_s seconds,
+    returning timeout_val if timeout_s seconds elapse and o has not
+    returned."""
     if isinstance(o, IDeref):
         return o.deref()
+    elif isinstance(o, IBlockingDeref):
+        return o.deref(timeout_s, timeout_val)
     raise TypeError(f"Object of type {type(o)} cannot be dereferenced")
 
 
@@ -961,6 +985,11 @@ def get(m, k, default=None):
         return default
 
 
+def is_special_form(s: sym.Symbol) -> bool:
+    """Return True if s names a special form."""
+    return s in _SPECIAL_FORMS
+
+
 @functools.singledispatch
 def to_lisp(o, keywordize_keys: bool = True):
     """Recursively convert Python collections into Lisp collections."""
@@ -971,26 +1000,26 @@ def to_lisp(o, keywordize_keys: bool = True):
 
 
 def _to_lisp_backup(o, keywordize_keys: bool = True):  # pragma: no cover
-    if isinstance(o, (list, tuple)):
-        return _to_lisp_vec(o, keywordize_keys=keywordize_keys)
-    elif isinstance(o, dict):
+    if isinstance(o, Mapping):
         return _to_lisp_map(o, keywordize_keys=keywordize_keys)
-    elif isinstance(o, (frozenset, set)):
+    elif isinstance(o, AbstractSet):
         return _to_lisp_set(o, keywordize_keys=keywordize_keys)
+    elif isinstance(o, Iterable):
+        return _to_lisp_vec(o, keywordize_keys=keywordize_keys)
     else:
         return o
 
 
 @to_lisp.register(list)
 @to_lisp.register(tuple)
-def _to_lisp_vec(o: Union[list, tuple], keywordize_keys: bool = True) -> vec.Vector:
+def _to_lisp_vec(o: Iterable, keywordize_keys: bool = True) -> vec.Vector:
     return vec.vector(
         map(functools.partial(to_lisp, keywordize_keys=keywordize_keys), o)
     )
 
 
 @to_lisp.register(dict)
-def _to_lisp_map(o: dict, keywordize_keys: bool = True) -> lmap.Map:
+def _to_lisp_map(o: Mapping, keywordize_keys: bool = True) -> lmap.Map:
     kvs = {}
     for k, v in o.items():
         if isinstance(k, str) and keywordize_keys:
@@ -1004,7 +1033,7 @@ def _to_lisp_map(o: dict, keywordize_keys: bool = True) -> lmap.Map:
 
 @to_lisp.register(frozenset)
 @to_lisp.register(set)
-def _to_lisp_set(o: Union[frozenset, set], keywordize_keys: bool = True) -> lset.Set:
+def _to_lisp_set(o: AbstractSet, keywordize_keys: bool = True) -> lset.Set:
     return lset.set(map(functools.partial(to_lisp, keywordize_keys=keywordize_keys), o))
 
 
@@ -1017,7 +1046,9 @@ def to_py(o, keyword_fn: Callable[[kw.Keyword], Any] = _kw_name):
     """Recursively convert Lisp collections into Python collections."""
     if isinstance(o, ISeq):
         return _to_py_list(o, keyword_fn=keyword_fn)
-    elif not isinstance(o, (llist.List, lmap.Map, lset.Set, vec.Vector)):
+    elif not isinstance(
+        o, (IPersistentList, IPersistentMap, IPersistentSet, IPersistentVector)
+    ):
         return o
     else:  # pragma: no cover
         return _to_py_backup(o, keyword_fn=keyword_fn)
@@ -1026,11 +1057,11 @@ def to_py(o, keyword_fn: Callable[[kw.Keyword], Any] = _kw_name):
 def _to_py_backup(
     o, keyword_fn: Callable[[kw.Keyword], Any] = _kw_name
 ):  # pragma: no cover
-    if isinstance(o, (llist.List, vec.Vector)):
+    if isinstance(o, (IPersistentList, IPersistentVector)):
         return _to_py_list(o, keyword_fn=keyword_fn)
-    elif isinstance(o, lmap.Map):
+    elif isinstance(o, IPersistentMap):
         return _to_py_map(o, keyword_fn=keyword_fn)
-    elif isinstance(o, lset.Set):
+    elif isinstance(o, IPersistentSet):
         return _to_py_set(o, keyword_fn=keyword_fn)
     else:
         return o
@@ -1045,24 +1076,26 @@ def _to_py_kw(o: kw.Keyword, keyword_fn: Callable[[kw.Keyword], Any] = _kw_name)
 @to_py.register(ISeq)
 @to_py.register(vec.Vector)
 def _to_py_list(
-    o: Union[llist.List, ISeq, vec.Vector],
+    o: Union[IPersistentList, ISeq, IPersistentVector],
     keyword_fn: Callable[[kw.Keyword], Any] = _kw_name,
 ) -> list:
     return list(map(functools.partial(to_py, keyword_fn=keyword_fn), o))
 
 
 @to_py.register(lmap.Map)
-def _to_py_map(o: lmap.Map, keyword_fn: Callable[[kw.Keyword], Any] = _kw_name) -> dict:
+def _to_py_map(
+    o: IPersistentMap, keyword_fn: Callable[[kw.Keyword], Any] = _kw_name
+) -> dict:
     return {
-        to_py(entry.key, keyword_fn=keyword_fn): to_py(
-            entry.value, keyword_fn=keyword_fn
-        )
-        for entry in o
+        to_py(key, keyword_fn=keyword_fn): to_py(value, keyword_fn=keyword_fn)
+        for key, value in o
     }
 
 
 @to_py.register(lset.Set)
-def _to_py_set(o: lset.Set, keyword_fn: Callable[[kw.Keyword], Any] = _kw_name) -> set:
+def _to_py_set(
+    o: IPersistentSet, keyword_fn: Callable[[kw.Keyword], Any] = _kw_name
+) -> set:
     return set(to_py(e, keyword_fn=keyword_fn) for e in o)
 
 
@@ -1214,6 +1247,7 @@ def _basilisp_fn(f):
     """Create a Basilisp function, setting meta and supplying a with_meta
     method implementation."""
     assert not hasattr(f, "meta")
+    f._basilisp_fn = True
     f.meta = None
     f.with_meta = partial(_fn_with_meta, f)
     return f

--- a/src/basilisp/lang/set.py
+++ b/src/basilisp/lang/set.py
@@ -8,7 +8,6 @@ from basilisp.lang.interfaces import (
     IPersistentMap,
     IPersistentSet,
     ISeq,
-    ISeqable,
 )
 from basilisp.lang.obj import seq_lrepr as _seq_lrepr
 from basilisp.lang.seq import sequence
@@ -16,7 +15,7 @@ from basilisp.lang.seq import sequence
 T = TypeVar("T")
 
 
-class Set(IMeta, ILispObject, ISeqable[T], IPersistentSet[T]):
+class Set(IMeta, ILispObject, IPersistentSet[T]):
     """Basilisp Set. Delegates internally to a pyrsistent.PSet object.
 
     Do not instantiate directly. Instead use the s() and set() factory

--- a/src/basilisp/lang/vector.py
+++ b/src/basilisp/lang/vector.py
@@ -8,7 +8,6 @@ from basilisp.lang.interfaces import (
     IPersistentMap,
     IPersistentVector,
     ISeq,
-    ISeqable,
 )
 from basilisp.lang.obj import seq_lrepr as _seq_lrepr
 from basilisp.lang.seq import sequence
@@ -16,7 +15,7 @@ from basilisp.lang.seq import sequence
 T = TypeVar("T")
 
 
-class Vector(ILispObject, IMeta, ISeqable[T], IPersistentVector[T]):  # type: ignore
+class Vector(ILispObject, IMeta, IPersistentVector[T]):  # type: ignore
     """Basilisp Vector. Delegates internally to a pyrsistent.PVector object.
     Do not instantiate directly. Instead use the v() and vec() factory
     methods below."""
@@ -60,7 +59,7 @@ class Vector(ILispObject, IMeta, ISeqable[T], IPersistentVector[T]):  # type: ig
         new_meta = meta if self._meta is None else self._meta.update(meta)
         return vector(self._inner, meta=new_meta)
 
-    def cons(self, *elems: T) -> "Vector[T]":
+    def cons(self, *elems: T) -> "Vector[T]":  # type: ignore
         e = self._inner.evolver()
         for elem in elems:
             e.append(elem)
@@ -82,7 +81,7 @@ class Vector(ILispObject, IMeta, ISeqable[T], IPersistentVector[T]):  # type: ig
     def empty() -> "Vector[T]":
         return v()
 
-    def seq(self) -> ISeq[T]:
+    def seq(self) -> ISeq[T]:  # type: ignore
         return sequence(self)
 
     def peek(self) -> Optional[T]:


### PR DESCRIPTION
After #370, there was a little bit of follow up work to clean up the interface hierarchy to more closely match Clojure.