### PR TITLE
Allow default values for deftype* fields

### DIFF
--- a/src/basilisp/lang/compiler/constants.py
+++ b/src/basilisp/lang/compiler/constants.py
@@ -135,6 +135,7 @@ OBJECT_DUNDER_METHODS = frozenset(
 
 SYM_ASYNC_META_KEY = kw.keyword("async")
 SYM_CLASSMETHOD_META_KEY = kw.keyword("classmethod")
+SYM_DEFAULT_META_KEY = kw.keyword("default")
 SYM_DYNAMIC_META_KEY = kw.keyword("dynamic")
 SYM_PROPERTY_META_KEY = kw.keyword("property")
 SYM_MACRO_META_KEY = kw.keyword("macro")

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -91,7 +91,7 @@ from basilisp.lang.compiler.nodes import (
     Vector as VectorNode,
     WithMeta,
 )
-from basilisp.lang.interfaces import IMeta, ISeq
+from basilisp.lang.interfaces import IMeta, IRecord, ISeq, ISeqable, IType
 from basilisp.lang.runtime import CORE_NS, NS_VAR_NAME as LISP_NS_VAR, Var
 from basilisp.lang.typing import LispForm
 from basilisp.lang.util import count, genname, munge
@@ -893,17 +893,29 @@ def _deftype_to_py_ast(  # pylint: disable=too-many-branches
 
     with ctx.new_symbol_table(node.name):
         type_nodes = []
+        type_deps: List[ast.AST] = []
         for field in node.fields:
             safe_field = munge(field.name)
+
+            if field.init is not None:
+                default_nodes = gen_py_ast(ctx, field.init)
+                type_deps.extend(default_nodes.dependencies)
+                attr_default_kws = [
+                    ast.keyword(arg="default", value=default_nodes.node)
+                ]
+            else:
+                attr_default_kws = []
+
             type_nodes.append(
                 ast.Assign(
                     targets=[ast.Name(id=safe_field, ctx=ast.Store())],
-                    value=ast.Call(func=_ATTRIB_FIELD_FN_NAME, args=[], keywords=[]),
+                    value=ast.Call(
+                        func=_ATTRIB_FIELD_FN_NAME, args=[], keywords=attr_default_kws
+                    ),
                 )
             )
             ctx.symbol_table.new_symbol(sym.symbol(field.name), safe_field, field.local)
 
-        type_deps: List[ast.AST] = []
         for member in node.members:
             type_ast = __deftype_member_to_py_ast(ctx, member)
             type_nodes.append(type_ast.node)  # type: ignore

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -91,7 +91,7 @@ from basilisp.lang.compiler.nodes import (
     Vector as VectorNode,
     WithMeta,
 )
-from basilisp.lang.interfaces import IMeta, IRecord, ISeq, ISeqable, IType
+from basilisp.lang.interfaces import IMeta, ISeq
 from basilisp.lang.runtime import CORE_NS, NS_VAR_NAME as LISP_NS_VAR, Var
 from basilisp.lang.typing import LispForm
 from basilisp.lang.util import count, genname, munge

--- a/src/basilisp/lang/compiler/parser.py
+++ b/src/basilisp/lang/compiler/parser.py
@@ -53,6 +53,7 @@ from basilisp.lang.compiler.constants import (
     OBJECT_DUNDER_METHODS,
     SYM_ASYNC_META_KEY,
     SYM_CLASSMETHOD_META_KEY,
+    SYM_DEFAULT_META_KEY,
     SYM_DYNAMIC_META_KEY,
     SYM_MACRO_META_KEY,
     SYM_MUTABLE_META_KEY,
@@ -451,6 +452,7 @@ def _meta_getter(meta_kw: kw.Keyword) -> MetaGetter:
 
 
 _is_async = _meta_getter(SYM_ASYNC_META_KEY)
+_is_mutable = _meta_getter(SYM_MUTABLE_META_KEY)
 _is_py_classmethod = _meta_getter(SYM_CLASSMETHOD_META_KEY)
 _is_py_property = _meta_getter(SYM_PROPERTY_META_KEY)
 _is_py_staticmethod = _meta_getter(SYM_STATICMETHOD_META_KEY)
@@ -1125,6 +1127,9 @@ def __assert_deftype_impls_are_abstract(  # pylint: disable=too-many-branches,to
         )
 
 
+__DEFTYPE_DEFAULT_SENTINEL = object()
+
+
 def _deftype_ast(ctx: ParserContext, form: ISeq) -> DefType:
     assert form.first == SpecialForm.DEFTYPE
 
@@ -1154,6 +1159,7 @@ def _deftype_ast(ctx: ParserContext, form: ISeq) -> DefType:
             f"deftype* fields must be vector, not {type(fields)}", form=fields
         )
 
+    has_defaults = False
     with ctx.new_symbol_table(name.name):
         is_frozen = True
         param_nodes = []
@@ -1161,11 +1167,25 @@ def _deftype_ast(ctx: ParserContext, form: ISeq) -> DefType:
             if not isinstance(field, sym.Symbol):
                 raise ParserException(f"deftype* fields must be symbols", form=field)
 
-            is_mutable = (
+            field_default = (
                 Maybe(field.meta)
-                .map(lambda m: m.entry(SYM_MUTABLE_META_KEY))  # type: ignore
-                .or_else_get(False)
+                .map(
+                    lambda m: m.entry(  # type: ignore
+                        SYM_DEFAULT_META_KEY, __DEFTYPE_DEFAULT_SENTINEL
+                    )
+                )
+                .value
             )
+            if not has_defaults and field_default is not __DEFTYPE_DEFAULT_SENTINEL:
+                has_defaults = True
+            elif has_defaults and field_default is __DEFTYPE_DEFAULT_SENTINEL:
+                raise ParserException(
+                    "deftype* fields without defaults may not appear after fields "
+                    "without defaults",
+                    form=field,
+                )
+
+            is_mutable = _is_mutable(field)
             if is_mutable:
                 is_frozen = False
 
@@ -1175,6 +1195,9 @@ def _deftype_ast(ctx: ParserContext, form: ISeq) -> DefType:
                 local=LocalType.FIELD,
                 is_assignable=is_mutable,
                 env=ctx.get_node_env(),
+                init=parse_ast(ctx, field_default)
+                if field_default is not __DEFTYPE_DEFAULT_SENTINEL
+                else None,
             )
             param_nodes.append(binding)
             ctx.put_new_symbol(field, binding, warn_if_unused=False)

--- a/src/basilisp/lang/compiler/parser.py
+++ b/src/basilisp/lang/compiler/parser.py
@@ -1130,7 +1130,9 @@ def __assert_deftype_impls_are_abstract(  # pylint: disable=too-many-branches,to
 __DEFTYPE_DEFAULT_SENTINEL = object()
 
 
-def _deftype_ast(ctx: ParserContext, form: ISeq) -> DefType:
+def _deftype_ast(  # pylint: disable=too-many-branches
+    ctx: ParserContext, form: ISeq
+) -> DefType:
     assert form.first == SpecialForm.DEFTYPE
 
     nelems = count(form)

--- a/tests/basilisp/compiler_test.py
+++ b/tests/basilisp/compiler_test.py
@@ -618,6 +618,28 @@ class TestDefType:
                 """
                 )
 
+        def test_deftype_allow_default_fields(self, ns: runtime.Namespace):
+            Point = lcompile("(deftype* Point [x ^{:default 2} y ^{:default 3} z])")
+            pt = Point(1)
+            assert (1, 2, 3) == (pt.x, pt.y, pt.z)
+            pt1 = Point(1, 4)
+            assert (1, 4, 3) == (pt1.x, pt1.y, pt1.z)
+            pt2 = Point(1, 4, 5)
+            assert (1, 4, 5) == (pt2.x, pt2.y, pt2.z)
+
+        @pytest.mark.parametrize(
+            "code",
+            [
+                "(deftype* Point [^{:default 1} x y z])",
+                "(deftype* Point [x ^{:default 2} y z])",
+            ],
+        )
+        def test_deftype_disallow_non_default_fields_after_default(
+            self, ns: runtime.Namespace, code: str
+        ):
+            with pytest.raises(compiler.CompilerException):
+                lcompile(code)
+
     class TestDefTypeMember:
         @pytest.mark.parametrize(
             "code",


### PR DESCRIPTION
Fixes #381 

Broken out of #374 